### PR TITLE
Fix winehq repository for Ubuntu in Dockerfile. Bionic repo is damaged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y wget gnupg software-properties-common
 RUN dpkg --add-architecture i386
 
 RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key && apt-key add winehq.key
-RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main'
+RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ xenial main'
 RUN apt-get update && apt-get install -y \
     winehq-stable \
 	alsa-utils \

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ cd ~/wine
 
 # Install brew if not exist
 brew install pulseaudio
+# Enable needed module
+sed -i -- '/#load-module\ module-native-protocol-tcp/s/^#//g' /usr/local/opt/pulseaudio/etc/pulse/default.pa
+
 brew services start pulseaudio
 
 # Build image
@@ -31,11 +34,6 @@ Checks before start
 # Check sound
 ./sound_test.sh
 # Should make a noise // Press Ctrl+C to stop
-
-# Check x11
-./x11_test.sh
-# Should open windows notepad // Close by x in ui 
-
 ```
 
 Start wine

--- a/start_wine.sh
+++ b/start_wine.sh
@@ -33,6 +33,7 @@ docker run -it \
 --volume="$HOME/.config/pulse:/root/.config/pulse" \
 --hostname="winecellar" \
 --name="wine" \
+-w /root/ \
 --privileged \
 wine bash
 


### PR DESCRIPTION
 - Fix winehq repository for Ubuntu in Dockerfile
 - Update README.md. Now we should enable module-native-protocol-tcp for pulseaudio before start
 - Fix workdir in start_wine.sh script

